### PR TITLE
Fix version 0.0.0: use release sdist URL instead of GitHub auto-archive

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
   imports:
     - firecrown
   commands:
-    - {{ PYTHON }} -c "import firecrown, importlib.metadata as md; assert firecrown.__version__ == '{{ version }}'; assert md.version('firecrown') == '{{ version }}'"
+    - python -c "import firecrown, importlib.metadata as md; assert firecrown.__version__ == '{{ version }}'; assert md.version('firecrown') == '{{ version }}'"
 
 about:
   home: https://github.com/LSSTDESC/firecrown

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,13 +5,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/LSSTDESC/firecrown/archive/v{{ version }}.tar.gz
-  sha256: 8cf67ee98dcdd891e4b4fc3f249fc79e41a5d5b2a585a2ebbb036352216043bd
+  url: https://github.com/LSSTDESC/firecrown/releases/download/v{{ version }}/firecrown-{{ version }}.tar.gz
+  sha256: ef95dcb6989b636191d2ea0d235e1783c57d0edbf64379e7f454c0824fb419a8
 
 build:
   skip: true  # [win or py<311]
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -21,6 +21,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools-scm
   run:
     - charset-normalizer
     - clmm
@@ -54,6 +55,8 @@ requirements:
 test:
   imports:
     - firecrown
+  commands:
+    - {{ PYTHON }} -c "import firecrown, importlib.metadata as md; assert firecrown.__version__ == '{{ version }}'; assert md.version('firecrown') == '{{ version }}'"
 
 about:
   home: https://github.com/LSSTDESC/firecrown


### PR DESCRIPTION
## Summary

The shipped `1.15.0` package reports `firecrown.__version__ == '0.0.0'` (or raises `LookupError` on newer setuptools-scm) because the recipe `source.url` pointed at the GitHub **auto-generated archive** (`/archive/v1.15.0.tar.gz`). That tarball has no `.git`, no `PKG-INFO`, and no `.git_archival.txt`, so `setuptools-scm` cannot determine the version at build time.

## Root cause

`firecrown` uses `setuptools-scm` dynamic versioning (`pyproject.toml` `[tool.setuptools_scm]`). The **release sdist** asset (`/releases/download/v1.15.0/firecrown-1.15.0.tar.gz`) ships `PKG-INFO` with `Version: 1.15.0` and builds correctly even with `--no-deps --no-build-isolation`. The auto-archive does not.

## Changes

- `source.url`: switched from `/archive/v{{ version }}.tar.gz` to the release sdist at `/releases/download/v{{ version }}/firecrown-{{ version }}.tar.gz`
- `source.sha256`: updated to the sdist asset sha256 (`ef95dcb6...`)
- `build.number`: bumped to `1` (corrected rebuild of `1.15.0`)
- `build.script`: added `--no-deps --no-build-isolation` (confirmed correct for sdist path)
- `requirements.host`: added `setuptools-scm` (reads `PKG-INFO` from the sdist)
- `test.commands`: added version assertion so any future version mismatch fails the build immediately

## Verification

Installing from the unpacked release sdist with `--no-deps --no-build-isolation` produces `metadata: 1.15.0` (reproduced locally). The auto-archive path fails/falls back regardless of this change.

@conda-forge-admin, please rerender